### PR TITLE
Fix android dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run the development app on a connected device or emulator:
 **Android**
 
 ```bash
-yarn androidDevelopmentDebug
+yarn androidDevDebug
 ```
 
 **iOS**
@@ -57,6 +57,12 @@ Extract the latest release of rgb_libFFI.xcframework.zip from [rgb-lib-swift/rel
 ```bash
 yarn ios --scheme=tribe-dev
 ```
+
+#### Development Commands
+
+Run useful scripts from `package.json` while developing:
+
+- `yarn androidDevDebug` – build and start the Android development variant.
 
 ## Verify Authenticity of Android APK
 


### PR DESCRIPTION
## Summary
- update README to use `yarn androidDevDebug`
- add a short development commands section

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5d474588323b1f4d9450e735b92