### PR TITLE
Implement secure store remove function

### DIFF
--- a/__tests__/secure-store.test.ts
+++ b/__tests__/secure-store.test.ts
@@ -1,0 +1,12 @@
+import {it, expect} from '@jest/globals';
+import * as Keychain from 'react-native-keychain';
+import {remove} from '../src/storage/secure-store';
+
+jest.mock('react-native-keychain', () => ({
+  resetGenericPassword: jest.fn(),
+}));
+
+it('remove resolves true when resetGenericPassword succeeds', async () => {
+  (Keychain.resetGenericPassword as jest.Mock).mockResolvedValue(true);
+  await expect(remove('test')).resolves.toBe(true);
+});

--- a/src/storage/secure-store.ts
+++ b/src/storage/secure-store.ts
@@ -60,12 +60,11 @@ export const hasPin = async () => {
 
 export const remove = async key => {
   try {
-    //
+    return await Keychain.resetGenericPassword();
   } catch (err) {
     console.log(err);
     return false;
   }
-  return true;
 };
 
 export const storeBiometricPubKey = async (pubKey: string) => {


### PR DESCRIPTION
## Summary
- implement `remove` method in secure-store
- add unit test to ensure `remove` resolves true on success

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5cbddbc8323aa43bdf08932298a