### PR TITLE
Release v0.4.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,7 +82,7 @@ android {
         applicationId "com.bithyve.tribe"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 144
+        versionCode 145
         versionName "0.4.0"
         missingDimensionStrategy 'react-native-camera', 'general'
         manifestPlaceholders = [

--- a/ios/tribe-dev-Info.plist
+++ b/ios/tribe-dev-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>144</string>
+	<string>145</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/tribe.xcodeproj/project.pbxproj
+++ b/ios/tribe.xcodeproj/project.pbxproj
@@ -749,7 +749,7 @@
 				CODE_SIGN_ENTITLEMENTS = tribe/tribe.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = Y5TCB759QL;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = tribe/Info.plist;
@@ -785,7 +785,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = Y5TCB759QL;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y5TCB759QL;
 				INFOPLIST_FILE = tribe/Info.plist;
@@ -822,7 +822,7 @@
 				CODE_SIGN_ENTITLEMENTS = "tribe-dev.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = Y5TCB759QL;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "tribe-dev-Info.plist";
@@ -858,7 +858,7 @@
 				CODE_SIGN_ENTITLEMENTS = "tribe-dev.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 144;
+				CURRENT_PROJECT_VERSION = 145;
 				DEVELOPMENT_TEAM = Y5TCB759QL;
 				INFOPLIST_FILE = "tribe-dev-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Tribe Dev";

--- a/ios/tribe/Info.plist
+++ b/ios/tribe/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>144</string>
+	<string>145</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/src/screens/assets/SendAssetScreen.tsx
+++ b/src/screens/assets/SendAssetScreen.tsx
@@ -68,6 +68,7 @@ type ItemProps = {
   assetId?: string;
   amount?: string;
   verified?: boolean;
+  iconUrl?: string;
 };
 
 const AssetItem = ({
@@ -80,6 +81,7 @@ const AssetItem = ({
   assetId,
   amount,
   verified,
+  iconUrl
 }: ItemProps) => {
   const theme: AppTheme = useTheme();
   const [isThemeDark] = useMMKVBoolean(Keys.THEME_MODE);
@@ -106,7 +108,7 @@ const AssetItem = ({
           <View style={styles.identiconWrapper}>
             {/* <View style={styles.identiconWrapper2}> */}
             <AssetIcon
-              iconUrl={ticker}
+              iconUrl={iconUrl}
               assetID={assetId}
               size={50}
               verified={verified}
@@ -461,6 +463,7 @@ const SendAssetScreen = () => {
           assetId={assetId}
           amount={assetData?.balance.spendable}
           verified={assetData?.issuer?.verified}
+          iconUrl={assetData.iconUrl}
         />
         <AppText variant="body2" style={styles.labelstyle}>
           {sendScreen.recipientInvoice}

--- a/src/screens/collectiblesCoins/components/AllocatedAssets.tsx
+++ b/src/screens/collectiblesCoins/components/AllocatedAssets.tsx
@@ -43,7 +43,7 @@ const AllocatedAssets = ({ asset }: allocatedAssetsProps) => {
           />
         ) : (
           <AssetIcon
-            assetTicker={asset.ticker}
+            iconUrl={asset.iconUrl}
             assetID={asset.assetId}
             size={30}
             verified={asset?.issuer?.verified}


### PR DESCRIPTION
- Upgraded to rgb-lib 0.11.1.alpha.2
- Embedded tweets in asset details
- Default asset shown on Home Screen
- Generate Invoice with Asset ID and Amount
- Wallet settings renamed to xPUB & UTXOs
- Asset send issues on Android & iOS fixed
- “Send Max” and Share to X bugs resolved
- Verification modal, tweet embed, and input issues fixed
- Prevented tweet display for unverified assets
- Improved UI and verification flow