### PR TITLE
Remove plaintext credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,24 @@ Before getting started, make sure you have a proper [React Native development en
 3. Install the project dependencies using Yarn:
    The prepare scripts will automatically install pods and nodify crypto-related packages for react-native
    ```shell
-   yarn install
-   ```
+  yarn install
+  ```
+
+### Environment Variables
+
+The build scripts expect several credentials to be provided via environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `MYAPP_RELEASE_STORE_FILE` | Path to the Android keystore used for signing release builds |
+| `MYAPP_RELEASE_KEY_ALIAS` | Alias of the signing key |
+| `MYAPP_RELEASE_STORE_PASSWORD` | Keystore password |
+| `MYAPP_RELEASE_KEY_PASSWORD` | Key password |
+| `STORE_PASSWORD` | Same as `MYAPP_RELEASE_STORE_PASSWORD`, used by Fastlane |
+| `KEY_PASSWORD` | Same as `MYAPP_RELEASE_KEY_PASSWORD`, used by Fastlane |
+| `KEY_ALIAS` | Same as `MYAPP_RELEASE_KEY_ALIAS`, used by Fastlane |
+| `SENTRY_AUTH_TOKEN` | Authentication token for uploading build artifacts to Sentry |
+
 
 ## Build and Run
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,13 +89,21 @@ android {
             appAuthRedirectScheme: 'tribe'
         ]
     }
+    def envOrProp = { name ->
+        return project.hasProperty(name) ? project.property(name) : System.getenv(name)
+    }
+
     signingConfigs {
         release {
-            if (project.hasProperty('MYAPP_RELEASE_STORE_FILE')) {
-                storeFile file(MYAPP_RELEASE_STORE_FILE)
-                storePassword MYAPP_RELEASE_STORE_PASSWORD
-                keyAlias MYAPP_RELEASE_KEY_ALIAS
-                keyPassword MYAPP_RELEASE_KEY_PASSWORD
+            def ksFile = envOrProp('MYAPP_RELEASE_STORE_FILE')
+            def ksPass = envOrProp('MYAPP_RELEASE_STORE_PASSWORD')
+            def keyAliasVal = envOrProp('MYAPP_RELEASE_KEY_ALIAS')
+            def keyPass = envOrProp('MYAPP_RELEASE_KEY_PASSWORD')
+            if (ksFile && ksPass && keyAliasVal && keyPass) {
+                storeFile file(ksFile)
+                storePassword ksPass
+                keyAlias keyAliasVal
+                keyPassword keyPass
             }
         }
         debug {

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,7 +46,7 @@ platform :android do
     store_password = ENV["STORE_PASSWORD"]
     key_password = ENV["KEY_PASSWORD"]
     key_alias = ENV["KEY_ALIAS"]
-    releaseFilePath = File.join(Dir.pwd, "..", "app", "release.keystore")
+    releaseFilePath = ENV["MYAPP_RELEASE_STORE_FILE"] || File.join(Dir.pwd, "..", "app", "release.keystore")
     gradle(task: 'clean')
     gradle(
       task: 'bundle',
@@ -77,7 +77,7 @@ platform :android do
     store_password = ENV["STORE_PASSWORD"]
     key_password = ENV["KEY_PASSWORD"]
     key_alias = ENV["KEY_ALIAS"]
-    releaseFilePath = File.join(Dir.pwd, "../app", "release.keystore")
+    releaseFilePath = ENV["MYAPP_RELEASE_STORE_FILE"] || File.join(Dir.pwd, "../app", "release.keystore")
     gradle(task: 'clean')
     gradle(
       task: 'bundle',

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,7 +41,3 @@ newArchEnabled=false
 hermesEnabled=true
 
 VisionCamera_enableCodeScanner=true
-MYAPP_RELEASE_STORE_FILE=release.keystore
-MYAPP_RELEASE_KEY_ALIAS=hexawallet
-MYAPP_RELEASE_STORE_PASSWORD=hexa@2021
-MYAPP_RELEASE_KEY_PASSWORD=hexa@2021 

--- a/android/sentry.properties
+++ b/android/sentry.properties
@@ -1,5 +1,4 @@
 
-auth.token=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
 
 defaults.org=bh-ph
 defaults.project=tribe

--- a/ios/sentry.properties
+++ b/ios/sentry.properties
@@ -1,5 +1,4 @@
 
-auth.token=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
 
 defaults.org=bh-ph
 defaults.project=tribe


### PR DESCRIPTION
## Summary
- scrub gradle.properties and sentry.properties of plaintext secrets
- look up signing details from env variables in build.gradle
- allow fastlane to override keystore path via env var
- document required environment variables

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848055fdfe0832383aab82b01dbd391