### PR TITLE
Improve openLink safety

### DIFF
--- a/src/utils/OpenLink.ts
+++ b/src/utils/OpenLink.ts
@@ -2,8 +2,14 @@ import { Linking } from 'react-native';
 
 export default async function openLink(urlPath: string) {
   try {
+    const canOpen = await Linking.canOpenURL(urlPath);
+    if (!canOpen) {
+      throw new Error(`Cannot open URL: ${urlPath}`);
+    }
+
     await Linking.openURL(urlPath);
   } catch (error) {
-    console.log(error);
+    console.error('Failed to open URL:', error);
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- add `Linking.canOpenURL` check
- throw errors so callers can handle failures

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848069db8c48323bf1bf564801e339b