### PR TITLE
Improve hexToBase64 error handling

### DIFF
--- a/__tests__/hexToBase64.test.ts
+++ b/__tests__/hexToBase64.test.ts
@@ -1,0 +1,13 @@
+import { hexToBase64 } from '../src/utils/hexToBase64';
+
+describe('hexToBase64', () => {
+  it('converts valid hex string to base64', () => {
+    const { base64, fileType } = hexToBase64('FFD8FF');
+    expect(base64).toBe('/9j/');
+    expect(fileType).toBe('image/jpeg');
+  });
+
+  it('throws on invalid hex string', () => {
+    expect(() => hexToBase64('abc')).toThrow('Invalid hex string');
+  });
+});

--- a/src/services/handler/apiHandler.ts
+++ b/src/services/handler/apiHandler.ts
@@ -1176,17 +1176,21 @@ export class ApiHandler {
             const mediaByte = await ApiHandler.api.getassetmedia({
               digest: collectible.media.digest,
             });
-            const { base64, fileType } = hexToBase64(mediaByte.bytes_hex);
-            const ext = assets.cfa[i].media.mime.split('/')[1];
-            const path = `${RNFS.DocumentDirectoryPath}/${collectible.media.digest}.${ext}`;
-            await RNFS.writeFile(path, base64, 'base64');
-            cfas.push({
-              ...assets.cfa[i],
-              media: {
-                ...assets.cfa[i].media,
-                filePath: path,
-              },
-            });
+            try {
+              const { base64, fileType } = hexToBase64(mediaByte.bytes_hex);
+              const ext = assets.cfa[i].media.mime.split('/')[1];
+              const path = `${RNFS.DocumentDirectoryPath}/${collectible.media.digest}.${ext}`;
+              await RNFS.writeFile(path, base64, 'base64');
+              cfas.push({
+                ...assets.cfa[i],
+                media: {
+                  ...assets.cfa[i].media,
+                  filePath: path,
+                },
+              });
+            } catch (error) {
+              console.warn('Invalid collectible media hex string', error);
+            }
           }
         }
         if (Platform.OS === 'ios' && ApiHandler.appType === AppType.ON_CHAIN) {

--- a/src/utils/hexToBase64.ts
+++ b/src/utils/hexToBase64.ts
@@ -1,24 +1,25 @@
-export const hexToBase64 = (hexString: string): {base64: string, fileType: string} => {
+export const hexToBase64 = (
+  hexString: string,
+): { base64: string; fileType: string } => {
+  const input = hexString.replace(/[^A-Fa-f0-9]/g, '');
+  if (!input || input.length % 2 !== 0) {
+    throw new Error('Invalid hex string');
+  }
 
-    const input = hexString.replace(/[^A-Fa-f0-9]/g, '');
-    if (input.length % 2) {
-        console.log('Cleaned hex string length is odd.');
-        return;
-    }
-    const binary = [];
-    for (let i = 0; i < input.length / 2; i++) {
-        const h = input.substr(i * 2, 2);
-        binary[i] = parseInt(h, 16);
-    }
-    const byteArray = Uint8Array.from(binary);
-    const base64 = Buffer.from(byteArray).toString('base64');
-    return {
-        base64,
-        fileType: determineFileType(hexString),
-    };
+  const binary = new Uint8Array(input.length / 2);
+  for (let i = 0; i < input.length / 2; i++) {
+    const h = input.substr(i * 2, 2);
+    binary[i] = parseInt(h, 16);
+  }
+
+  const base64 = Buffer.from(binary).toString('base64');
+  return {
+    base64,
+    fileType: determineFileType(hexString),
+  };
 };
 
-function determineFileType(hexString) {
+function determineFileType(hexString: string): string {
     const input = hexString.replace(/[^A-Fa-f0-9]/g, ''); // Clean non-hex chars
     const header = input.slice(0, 16).toUpperCase(); // Get the first 8 bytes
     const magicNumbers = {


### PR DESCRIPTION
## Summary
- validate hex strings in `hexToBase64`
- wrap collectible conversion in try/catch
- add tests for `hexToBase64`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848068928f08323b0ba200f9b5145ad