### PR TITLE
Improve hexToBase64 error handling

### DIFF
--- a/src/services/handler/apiHandler.ts
+++ b/src/services/handler/apiHandler.ts
@@ -1176,7 +1176,13 @@ export class ApiHandler {
             const mediaByte = await ApiHandler.api.getassetmedia({
               digest: collectible.media.digest,
             });
-            const { base64, fileType } = hexToBase64(mediaByte.bytes_hex);
+            let base64: string | undefined;
+            try {
+              ({ base64 } = hexToBase64(mediaByte.bytes_hex));
+            } catch (error) {
+              console.error('hexToBase64 failed', error);
+              continue;
+            }
             const ext = assets.cfa[i].media.mime.split('/')[1];
             const path = `${RNFS.DocumentDirectoryPath}/${collectible.media.digest}.${ext}`;
             await RNFS.writeFile(path, base64, 'base64');

--- a/src/utils/hexToBase64.ts
+++ b/src/utils/hexToBase64.ts
@@ -1,34 +1,37 @@
-export const hexToBase64 = (hexString: string): {base64: string, fileType: string} => {
+export const hexToBase64 = (
+  hexString: string,
+): { base64: string; fileType: string } => {
+  const sanitized = hexString.replace(/^0x/i, '').replace(/\s+/g, '');
 
-    const input = hexString.replace(/[^A-Fa-f0-9]/g, '');
-    if (input.length % 2) {
-        console.log('Cleaned hex string length is odd.');
-        return;
-    }
-    const binary = [];
-    for (let i = 0; i < input.length / 2; i++) {
-        const h = input.substr(i * 2, 2);
-        binary[i] = parseInt(h, 16);
-    }
-    const byteArray = Uint8Array.from(binary);
-    const base64 = Buffer.from(byteArray).toString('base64');
-    return {
-        base64,
-        fileType: determineFileType(hexString),
-    };
+  if (!/^[a-fA-F0-9]+$/.test(sanitized) || sanitized.length % 2 !== 0) {
+    throw new Error('Invalid hex string');
+  }
+
+  const binary: number[] = [];
+  for (let i = 0; i < sanitized.length / 2; i++) {
+    const h = sanitized.substr(i * 2, 2);
+    binary[i] = parseInt(h, 16);
+  }
+
+  const byteArray = Uint8Array.from(binary);
+  const base64 = Buffer.from(byteArray).toString('base64');
+  return {
+    base64,
+    fileType: determineFileType(sanitized),
+  };
 };
 
-function determineFileType(hexString) {
-    const input = hexString.replace(/[^A-Fa-f0-9]/g, ''); // Clean non-hex chars
-    const header = input.slice(0, 16).toUpperCase(); // Get the first 8 bytes
-    const magicNumbers = {
-        '89504E47': 'image/png',
-        'FFD8FF': 'image/jpeg',
-        '47494638': 'image/gif',
-        '424D': 'image/bmp',
-        '25504446': 'application/pdf',
-        '504B0304': 'application/zip',
-    };
+function determineFileType(hexString: string): string {
+  const input = hexString.replace(/[^A-Fa-f0-9]/g, ''); // Clean non-hex chars
+  const header = input.slice(0, 16).toUpperCase(); // Get the first 8 bytes
+  const magicNumbers: Record<string, string> = {
+    '89504E47': 'image/png',
+    'FFD8FF': 'image/jpeg',
+    '47494638': 'image/gif',
+    '424D': 'image/bmp',
+    '25504446': 'application/pdf',
+    '504B0304': 'application/zip',
+  };
 
     for (const [magic, type] of Object.entries(magicNumbers)) {
         if (header.startsWith(magic)) {


### PR DESCRIPTION
## Summary
- validate hex string in `hexToBase64`
- throw if invalid and catch this in `apiHandler`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480693b17c83239c6a7964638cf9f0