### PR TITLE
Fix stringToArrayBuffer return type

### DIFF
--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -70,7 +70,7 @@ export const generateRandomNumber = max => {
   return number;
 };
 
-export const stringToArrayBuffer = (byteString: string): Uint8Array => {
+export const stringToArrayBuffer = (byteString: string): Uint8Array | null => {
   if (byteString) {
     const byteArray = new Uint8Array(byteString.length);
     for (let i = 0; i < byteString.length; i++) {


### PR DESCRIPTION
## Summary
- allow `stringToArrayBuffer` to return `null`

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848069b07d88323a90a079d7583e904