### PR TITLE
Rename helper and update usage

### DIFF
--- a/src/services/handler/apiHandler.ts
+++ b/src/services/handler/apiHandler.ts
@@ -59,7 +59,7 @@ import { NativeModules, Platform } from 'react-native';
 import { BackupAction, CloudBackupAction } from 'src/models/enums/Backup';
 import AppType from 'src/models/enums/AppType';
 import { RLNNodeApiServices } from '../rgbnode/RLNNodeApi';
-import { snakeCaseToCamelCaseCase } from 'src/utils/snakeCaseToCamelCaseCase';
+import { snakeCaseToCamelCase } from 'src/utils/snakeCaseToCamelCaseCase';
 import Realm from 'realm';
 import { hexToBase64 } from 'src/utils/hexToBase64';
 import * as RNFS from '@dr.pogodin/react-native-fs';
@@ -1106,7 +1106,7 @@ export class ApiHandler {
     try {
       const response = await ApiHandler.api.decodelninvoice({ invoice });
       if (response.payment_hash) {
-        return snakeCaseToCamelCaseCase(response);
+        return snakeCaseToCamelCase(response);
       } else {
         throw new Error(response.error);
       }
@@ -1120,7 +1120,7 @@ export class ApiHandler {
     try {
       const response = await ApiHandler.api.sendPayment({ invoice });
       if (response.payment_hash) {
-        return snakeCaseToCamelCaseCase(response);
+        return snakeCaseToCamelCase(response);
       } else {
         throw new Error(response.error);
       }
@@ -1145,7 +1145,7 @@ export class ApiHandler {
             lnPayments: response?.payments,
           },
         );
-        return snakeCaseToCamelCaseCase(response.payments);
+        return snakeCaseToCamelCase(response.payments);
       } else {
         throw new Error(response.error);
       }
@@ -1489,7 +1489,7 @@ export class ApiHandler {
         });
         if (balances && balances.future) {
           dbManager.updateObjectByPrimaryId(schema, 'assetId', assetId, {
-            balance: snakeCaseToCamelCaseCase(balances),
+            balance: snakeCaseToCamelCase(balances),
           });
         }
       }
@@ -1956,9 +1956,9 @@ export class ApiHandler {
     try {
       const response = await ApiHandler.api.listchannels();
       if (response && response.channels) {
-        return snakeCaseToCamelCaseCase(response).channels;
+        return snakeCaseToCamelCase(response).channels;
       } else {
-        return snakeCaseToCamelCaseCase(response);
+        return snakeCaseToCamelCase(response);
       }
     } catch (error) {
       console.log(error);
@@ -2023,7 +2023,7 @@ export class ApiHandler {
         throw new Error(response.error);
       }
       if (response) {
-        return snakeCaseToCamelCaseCase(response);
+        return snakeCaseToCamelCase(response);
       } else {
         throw new Error('Failed to unlock node');
       }

--- a/src/services/rgb/RGBServices.ts
+++ b/src/services/rgb/RGBServices.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { RGBWallet } from 'src/models/interfaces/RGBWallet';
 import AppType from 'src/models/enums/AppType';
-import { snakeCaseToCamelCaseCase } from 'src/utils/snakeCaseToCamelCaseCase';
+import { snakeCaseToCamelCase } from 'src/utils/snakeCaseToCamelCaseCase';
 import { RLNNodeApiServices } from '../rgbnode/RLNNodeApi';
 import config from 'src/utils/config';
 
@@ -114,7 +114,7 @@ export default class RGBServices {
         filter_asset_schemas: ['Nia', 'Cfa'],
       });
       if (response) {
-        const data = snakeCaseToCamelCaseCase(response);
+        const data = snakeCaseToCamelCase(response);
         return data;
       } else {
         return response;
@@ -146,7 +146,7 @@ export default class RGBServices {
           duration_seconds: 86400,
         });
         if (response) {
-          const data = snakeCaseToCamelCaseCase(response);
+          const data = snakeCaseToCamelCase(response);
           return data;
         } else {
           return response;
@@ -172,7 +172,7 @@ export default class RGBServices {
         asset_id: assetId,
       });
       if (response) {
-        const data = snakeCaseToCamelCaseCase(response);
+        const data = snakeCaseToCamelCase(response);
         return data;
       } else {
         return response;
@@ -191,7 +191,7 @@ export default class RGBServices {
     if (appType === AppType.NODE_CONNECT) {
       const response = await api.listtransfers({ asset_id: assetId });
       if (response) {
-        const data = snakeCaseToCamelCaseCase(response.transfers.reverse());
+        const data = snakeCaseToCamelCase(response.transfers.reverse());
         return data;
       } else {
         return response;
@@ -218,7 +218,7 @@ export default class RGBServices {
         amounts: [Number(supply)],
       });
       if (response) {
-        const data = snakeCaseToCamelCaseCase(response);
+        const data = snakeCaseToCamelCase(response);
         return data;
       } else {
         return response;
@@ -249,7 +249,7 @@ export default class RGBServices {
           file_digest: responseDigest.digest,
         });
         if (response) {
-          const data = snakeCaseToCamelCaseCase(response);
+          const data = snakeCaseToCamelCase(response);
           return data.asset ? data.asset : data;
         } else {
           return response;
@@ -332,7 +332,7 @@ export default class RGBServices {
     if (appType === AppType.NODE_CONNECT) {
       const response = await api.listUnspents({ skip_sync: false });
       if (response) {
-        const data = snakeCaseToCamelCaseCase(response.unspents);
+        const data = snakeCaseToCamelCase(response.unspents);
         return data;
       } else {
         return response.error;

--- a/src/services/rgbnode/RLNNodeApi.ts
+++ b/src/services/rgbnode/RLNNodeApi.ts
@@ -1,4 +1,4 @@
-import { snakeCaseToCamelCaseCase } from 'src/utils/snakeCaseToCamelCaseCase';
+import { snakeCaseToCamelCase } from 'src/utils/snakeCaseToCamelCaseCase';
 
 export interface ApiConfig {
   baseUrl: string;
@@ -50,7 +50,7 @@ export class RLNNodeApiServices {
         Authorization: auth,
       },
     });
-    return snakeCaseToCamelCaseCase(await response.json());
+    return snakeCaseToCamelCase(await response.json());
   }
 
   public async getBtcBalance(body: { skip_sync: boolean }): Promise<{

--- a/src/utils/snakeCaseToCamelCaseCase.ts
+++ b/src/utils/snakeCaseToCamelCaseCase.ts
@@ -2,13 +2,13 @@ function toCamelCase(str: string): string {
   return str.replace(/_([a-z])/g, (match, letter) => letter.toUpperCase());
 }
 
-export function snakeCaseToCamelCaseCase(obj: any): any {
+export function snakeCaseToCamelCase(obj: any): any {
   if (Array.isArray(obj)) {
-    return obj.map(v => snakeCaseToCamelCaseCase(v));
+    return obj.map(v => snakeCaseToCamelCase(v));
   } else if (obj !== null && obj.constructor === Object) {
     return Object.keys(obj).reduce((result: any, key: string) => {
       const camelCaseKey = toCamelCase(key);
-      result[camelCaseKey] = snakeCaseToCamelCaseCase(obj[key]);
+      result[camelCaseKey] = snakeCaseToCamelCase(obj[key]);
       return result;
     }, {});
   }


### PR DESCRIPTION
## Summary
- rename snakeCaseToCamelCaseCase helper to `snakeCaseToCamelCase`
- update imports and usages across service modules

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_6848069c29b48323a4278a01736a5343