### PR TITLE
Fix typos in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ Before getting started, make sure you have a proper [React Native development en
    cd bitcoin-tribe
    ```
 3. Install the project dependencies using Yarn:
-   The prepare scripts will automatically install pods and nodify crypto-related packages for react-native
+   The prepare scripts will automatically install pods and nodeify crypto-related packages for react-native
    ```shell
    yarn install
    ```
 
 ## Build and Run
 
-### Varients
+### Variants
 
 The project has testnet and mainnet variants. The development variant is configured to use testnet and the production variant to use mainnet.
 
-Start metro metro
+Start metro
 
 ```bash
 yarn start


### PR DESCRIPTION
## Summary
- correct typo in build instructions
- fix duplicate word in metro startup section

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684806a145b08323a188d947cddcfadf