### PR TITLE
Improve hexToBase64 error handling

### DIFF
--- a/__tests__/hexToBase64.test.ts
+++ b/__tests__/hexToBase64.test.ts
@@ -1,0 +1,17 @@
+import {it, expect} from '@jest/globals';
+import {hexToBase64} from '../src/utils/hexToBase64';
+
+it('converts valid hex string to base64', () => {
+  const result = hexToBase64('48656c6c6f');
+  expect(result).not.toBeNull();
+  expect(result?.base64).toBe('SGVsbG8=');
+  expect(result?.fileType).toBe('unknown');
+});
+
+it('returns null for hex string with odd length', () => {
+  expect(hexToBase64('abc')).toBeNull();
+});
+
+it('returns null for hex string with invalid characters', () => {
+  expect(hexToBase64('zz')).toBeNull();
+});

--- a/src/services/handler/apiHandler.ts
+++ b/src/services/handler/apiHandler.ts
@@ -1184,17 +1184,20 @@ export class ApiHandler {
             const mediaByte = await ApiHandler.api.getassetmedia({
               digest: collectible.media.digest,
             });
-            const { base64, fileType } = hexToBase64(mediaByte.bytes_hex);
-            const ext = assets.cfa[i].media.mime.split('/')[1];
-            const path = `${RNFS.DocumentDirectoryPath}/${collectible.media.digest}.${ext}`;
-            await RNFS.writeFile(path, base64, 'base64');
-            cfas.push({
-              ...assets.cfa[i],
-              media: {
-                ...assets.cfa[i].media,
-                filePath: path,
-              },
-            });
+            const conversion = hexToBase64(mediaByte.bytes_hex);
+            if (conversion) {
+              const { base64 } = conversion;
+              const ext = assets.cfa[i].media.mime.split('/')[1];
+              const path = `${RNFS.DocumentDirectoryPath}/${collectible.media.digest}.${ext}`;
+              await RNFS.writeFile(path, base64, 'base64');
+              cfas.push({
+                ...assets.cfa[i],
+                media: {
+                  ...assets.cfa[i].media,
+                  filePath: path,
+                },
+              });
+            }
           }
         }
         if (Platform.OS === 'ios' && ApiHandler.appType === AppType.ON_CHAIN) {

--- a/src/utils/hexToBase64.ts
+++ b/src/utils/hexToBase64.ts
@@ -1,14 +1,18 @@
-export const hexToBase64 = (hexString: string): {base64: string, fileType: string} => {
-
-    const input = hexString.replace(/[^A-Fa-f0-9]/g, '');
-    if (input.length % 2) {
-        console.log('Cleaned hex string length is odd.');
-        return;
+export const hexToBase64 = (
+    hexString: string,
+): { base64: string; fileType: string } | null => {
+    const isValidHex = /^[0-9a-fA-F]+$/.test(hexString) && hexString.length % 2 === 0;
+    if (!isValidHex) {
+        return null;
     }
-    const binary = [];
-    for (let i = 0; i < input.length / 2; i++) {
-        const h = input.substr(i * 2, 2);
-        binary[i] = parseInt(h, 16);
+    const binary = [] as number[];
+    for (let i = 0; i < hexString.length / 2; i++) {
+        const h = hexString.substr(i * 2, 2);
+        const parsed = parseInt(h, 16);
+        if (Number.isNaN(parsed)) {
+            return null;
+        }
+        binary[i] = parsed;
     }
     const byteArray = Uint8Array.from(binary);
     const base64 = Buffer.from(byteArray).toString('base64');


### PR DESCRIPTION
## Summary
- handle invalid hex input in `hexToBase64`
- guard API handler against invalid conversion
- add `hexToBase64` unit tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481417cbe8832396a3c343b1548c8a