### PR TITLE
Add configurable Android SDK path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ Before getting started, make sure you have a proper [React Native development en
    cd bitcoin-tribe
    ```
 3. Install the project dependencies using Yarn:
-   The prepare scripts will automatically install pods and nodify crypto-related packages for react-native
+   The prepare scripts will automatically install pods, nodify crypto-related packages for React Native and
+   configure the Android SDK path. The setup script reads the location from `$ANDROID_HOME` or you can pass
+   a custom path.
    ```shell
-   yarn install
+   ANDROID_HOME=/path/to/sdk yarn install
+   # or run after installation
+   ./setup.sh /path/to/sdk
    ```
 
 ## Build and Run

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # enabling node core modules
 # adding node core modules support in react-native
 rn-nodeify --install buffer,events,process,stream,inherits,path,assert,crypto,constants --hack --yarn
@@ -6,4 +8,17 @@ rn-nodeify --install buffer,events,process,stream,inherits,path,assert,crypto,co
 cd ios && RCT_NEW_ARCH_ENABLED=0 pod install
 
 # android SDK location configuration
-cd ../android && touch local.properties && echo "sdk.dir = /Users/$(whoami)/Library/Android/sdk" >local.properties
+cd ../android
+
+# Determine Android SDK path. Prefer an argument, then ANDROID_HOME, then the
+# default macOS location.
+if [ -n "$1" ]; then
+  SDK_PATH="$1"
+elif [ -n "$ANDROID_HOME" ]; then
+  SDK_PATH="$ANDROID_HOME"
+else
+  SDK_PATH="/Users/$(whoami)/Library/Android/sdk"
+fi
+
+touch local.properties
+echo "sdk.dir = $SDK_PATH" > local.properties


### PR DESCRIPTION
## Summary
- allow setup.sh to read SDK path from argument or $ANDROID_HOME
- document SDK path configuration in README

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848141975348323b032c43b9894ac5d