### PR TITLE
Remove secrets from config files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Android signing credentials
+STORE_PASSWORD=
+KEY_PASSWORD=
+KEY_ALIAS=
+
+# Sentry authentication token
+SENTRY_AUTH_TOKEN=
+

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ yarn-error.log
 !.yarn/versions
 
 .env*
+!.env.example
 env*
 
 ios/rgb/rgb_libFFI.xcframework

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Before getting started, make sure you have a proper [React Native development en
    yarn install
    ```
 
+4. Copy `.env.example` to `.env` and fill in the required values.
+
 ## Build and Run
 
 ### Varients
@@ -131,6 +133,17 @@ Output should show PGP key **389F 4CAD A078 5AC0 E28A 0C18 1BEB DE26 1DC3 CF62**
 using RSA key 389F4CADA0785AC0E28A0C181BEBDE261DC3CF62
 issuer "hexa@bithyve.com"
 Good signature from "Hexa Team (Hexa Bitcoin Wallet) <hexa@bithyve.com>"
+```
+
+## Environment Variables
+
+Create a `.env` file in the project root (use `.env.example` as a template) and set the following variables:
+
+```bash
+STORE_PASSWORD=your_android_keystore_password
+KEY_PASSWORD=your_android_key_password
+KEY_ALIAS=your_android_key_alias
+SENTRY_AUTH_TOKEN=your_sentry_auth_token
 ```
 
 ## License

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,11 +91,15 @@ android {
     }
     signingConfigs {
         release {
-            if (project.hasProperty('MYAPP_RELEASE_STORE_FILE')) {
-                storeFile file(MYAPP_RELEASE_STORE_FILE)
-                storePassword MYAPP_RELEASE_STORE_PASSWORD
-                keyAlias MYAPP_RELEASE_KEY_ALIAS
-                keyPassword MYAPP_RELEASE_KEY_PASSWORD
+            def storeFilePath = System.getenv('RELEASE_STORE_FILE') ?: 'release.keystore'
+            def storePassword = System.getenv('STORE_PASSWORD')
+            def keyAlias = System.getenv('KEY_ALIAS')
+            def keyPassword = System.getenv('KEY_PASSWORD')
+            if (storePassword && keyAlias && keyPassword) {
+                storeFile file(storeFilePath)
+                storePassword storePassword
+                keyAlias keyAlias
+                keyPassword keyPassword
             }
         }
         debug {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,7 +41,3 @@ newArchEnabled=false
 hermesEnabled=true
 
 VisionCamera_enableCodeScanner=true
-MYAPP_RELEASE_STORE_FILE=release.keystore
-MYAPP_RELEASE_KEY_ALIAS=hexawallet
-MYAPP_RELEASE_STORE_PASSWORD=hexa@2021
-MYAPP_RELEASE_KEY_PASSWORD=hexa@2021 

--- a/android/sentry.properties
+++ b/android/sentry.properties
@@ -1,5 +1,5 @@
 
-auth.token=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
+auth.token=${SENTRY_AUTH_TOKEN}
 
 defaults.org=bh-ph
 defaults.project=tribe

--- a/ios/sentry.properties
+++ b/ios/sentry.properties
@@ -1,5 +1,5 @@
 
-auth.token=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
+auth.token=${SENTRY_AUTH_TOKEN}
 
 defaults.org=bh-ph
 defaults.project=tribe


### PR DESCRIPTION
## Summary
- load keystore passwords from env variables
- reference env var for Sentry auth token
- document required environment variables and add sample `.env.example`
- allow `.env.example` to be versioned

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68480d1f84fc83238accc59abdd60592