### PR TITLE
fixes incorrect navigation on create group 

### DIFF
--- a/src/screens/community/CreateGroup.tsx
+++ b/src/screens/community/CreateGroup.tsx
@@ -75,7 +75,7 @@ export const CreateGroup = () => {
 
   // Navigate to chat when room is created/joined
   useEffect(() => {
-    if (currentRoom) {
+    if (currentRoom && currentRoom.roomType != HolepunchRoomType.INBOX) {
       (navigation as any).navigate(NavigationRoutes.CHAT, {
         roomId: currentRoom.roomId,
       });


### PR DESCRIPTION
Addressing 
Blank “My Inbox” screen appears after navigating to Create Group during root-peer connection. #1674