### PR TITLE
chore: update orbis1-sdk-rn integration

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1925,7 +1925,7 @@ PODS:
   - react-native-app-auth (8.0.1):
     - AppAuth (>= 1.7.6)
     - React-Core
-  - "react-native-bare-kit (0.9.3+729192)":
+  - "react-native-bare-kit (0.9.3+5c479c)":
     - boost
     - DoubleConversion
     - fast_float
@@ -3889,7 +3889,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 94f4264de2cb156960cd82b338a403f4653f2fd9
   React-microtasksnativemodule: 6c4ee39a36958c39c97b074d28f360246a335e84
   react-native-app-auth: 0dd956abd9201fc06f7b4a71f0740836e2532014
-  react-native-bare-kit: 30efce22b91bc40474bbfc60064469e00db2b9ff
+  react-native-bare-kit: b9b049522e37ea8db379293aac184caae748ecf5
   react-native-biometrics: 43ed5b828646a7862dbc7945556446be00798e7d
   react-native-blur: 6af83e7e3c4c1446a188d9b2c493600fc4beb173
   react-native-config: c9a1b34b1d4edef7bea9fcfdd451bb1134c6a2b1

--- a/src/services/rgb/RGBServices.ts
+++ b/src/services/rgb/RGBServices.ts
@@ -2,12 +2,27 @@ import AppType from 'src/models/enums/AppType';
 import { snakeCaseToCamelCaseCase } from 'src/utils/snakeCaseToCamelCaseCase';
 import { RLNNodeApiServices } from '../rgbnode/RLNNodeApi';
 import config from 'src/utils/config';
-import { BitcoinNetwork, Wallet, AssetSchema, BtcBalance, decodeInvoice, InvoiceData, Transaction, Recipient, Assignment, Transfer, RefreshFilter, restoreBackup } from 'orbis1-sdk-rn';
+import { 
+  Orbis1SDK,
+  BitcoinNetwork, 
+  AssetSchema, 
+  BtcBalance, 
+  decodeInvoice, 
+  InvoiceData, 
+  Transaction, 
+  Recipient, 
+  Assignment, 
+  Transfer, 
+  RefreshFilter, 
+  restoreBackup,
+  LogLevel,
+} from 'orbis1-sdk-rn';
 import { NetworkType } from '../wallets/enums';
 import * as RNFS from '@dr.pogodin/react-native-fs';
 
 export default class RGBServices {
-  private static RGBWallet: Wallet;
+  private static sdk: Orbis1SDK | null = null;
+  private static RGBWallet: any = null; // Will be the Wallet instance from SDK
 
   static getBitcoinNetwork = (): BitcoinNetwork => {
     switch (config.NETWORK_TYPE) {
@@ -79,18 +94,45 @@ export default class RGBServices {
     try {
       const keys = {
         mnemonic: mnemonic,
+        xpub: xpub,
         accountXpubVanilla: accountXpubVanilla,
         accountXpubColored: accountXpubColored,
         masterFingerprint: masterFingerprint,
-        xpub: xpub,
-      }
-      RGBServices.RGBWallet = new Wallet(keys, {
-        network: this.getBitcoinNetwork(),
-        maxAllocationsPerUtxo: 1,
-        supportedSchemas: [AssetSchema.CFA, AssetSchema.NIA, AssetSchema.UDA],
-        vanillaKeychain: 0
+      };
+      
+      // Determine environment based on network
+      const network = this.getBitcoinNetwork();
+      
+      // Create SDK instance
+      RGBServices.sdk = new Orbis1SDK({
+        apiKey: config.ORBIS1_API_KEY, 
+        wallet: {
+          enabled: true,
+          keys,
+          network,
+          supportedSchemas: [AssetSchema.CFA, AssetSchema.NIA, AssetSchema.UDA],
+          maxAllocationsPerUtxo: 1,
+          vanillaKeychain: 0,
+        },
+        features: {
+          gasFree: { name: 'gasFree', enabled: false },
+          watchTower: { name: 'watchTower', enabled: false },
+        },
+        logging: { level: LogLevel.ERROR },
       });
+      
+      // Initialize SDK
+      await RGBServices.sdk.initialize();
+      
+      // Get wallet instance once and store it
+      RGBServices.RGBWallet = RGBServices.sdk.getWallet();
+      if (!RGBServices.RGBWallet) {
+        throw new Error('Failed to get wallet from SDK');
+      }
+      
+      // Connect wallet to Electrum
       await RGBServices.RGBWallet.goOnline(this.getElectrumUrl(this.getBitcoinNetwork()), false);
+      
       return {
         status: true,
         error: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7653,7 +7653,7 @@ ora@^5.4.1:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-orbis1-sdk-rn@^0.0.2:
+orbis1-sdk-rn@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/orbis1-sdk-rn/-/orbis1-sdk-rn-0.0.2.tgz#07109e4425ca5a7167ccd0330d77760fa6d4c08b"
   integrity sha512-q/TCWq0LhGX+ZLZELVpRgyKEWdoQur5Gn4sqp3wWmVVjqBreJgrsBJak2VRC9wa15thxJkdaXPu9Yc5Q3QHoqQ==


### PR DESCRIPTION
This pull request refactors the RGB wallet initialization process in the `RGBServices` class to use the new `Orbis1SDK` instead of directly instantiating the wallet. The changes modernize the integration with the SDK, add new configuration options, and improve error handling when retrieving the wallet instance.

**SDK Integration and Wallet Initialization:**

* Replaces direct instantiation of the wallet with initialization via `Orbis1SDK`, storing the SDK instance in `RGBServices.sdk` and retrieving the wallet using `sdk.getWallet()`. 
* Adds new SDK configuration options, including API key, supported asset schemas, feature flags (`gasFree`, `watchTower`), and log level settings.
* Improves error handling by throwing an error if the wallet instance cannot be retrieved from the SDK.
* Updates the wallet connection logic to use Electrum after SDK-based initialization