### PR TITLE
feat: add ticker display to SendAssetSuccess and fix asset amount comparison

### DIFF
--- a/src/screens/assets/SendAssetScreen.tsx
+++ b/src/screens/assets/SendAssetScreen.tsx
@@ -873,6 +873,7 @@ const SendAssetScreen = () => {
             // transID={idx(sendTransactionMutation, _ => _.data.txid) || ''}
             assetName={formatTUsdt(assetData?.name)}
             amount={assetAmount && assetAmount.replace(/,/g, '')}
+            ticker={assetData?.ticker}
             feeRate={
               selectedPriority === TxPriority.CUSTOM
                 ? customFee
@@ -926,7 +927,7 @@ const SendAssetScreen = () => {
         <Buttons
           primaryTitle={requestingQuote ? 'Preparing Transaction...' : common.next}
           primaryOnPress={async () => {
-            if (Number(assetAmount) > assetData?.balance.spendable) {
+            if (Number(assetAmount) > Number(assetData?.balance.spendable)) {
               Keyboard.dismiss();
               if (Number(assetData?.balance.spendable) === 0) {
                 setAmountValidationError(

--- a/src/screens/assets/components/SendAssetSuccess.tsx
+++ b/src/screens/assets/components/SendAssetSuccess.tsx
@@ -12,6 +12,7 @@ import PrimaryCTA from 'src/components/PrimaryCTA';
 type sendAssetSuccessProps = {
   assetName: string;
   amount: string;
+  ticker?: string;
   feeRate: string;
   onPress: () => void;
   onSuccessStatus: boolean;
@@ -28,6 +29,7 @@ function SendAssetSuccess(props: sendAssetSuccessProps) {
   const {
     assetName,
     amount,
+    ticker,
     onPress,
     feeRate,
     onSuccessStatus,
@@ -124,7 +126,7 @@ function SendAssetSuccess(props: sendAssetSuccessProps) {
         </View>
         <View style={styles.valueWrapper}>
           <AppText variant="body1" style={styles.valueText}>
-            {amount}
+            {amount} {ticker || ''}
           </AppText>
         </View>
       </View>


### PR DESCRIPTION
This pull request updates the asset sending flow to improve clarity for users by displaying the asset ticker alongside the amount, and ensures more robust validation of the spendable balance. The changes primarily affect the `SendAssetScreen` and `SendAssetSuccess` components.

**User interface improvements:**

* [`src/screens/assets/components/SendAssetSuccess.tsx`](diffhunk://#diff-4584ea8adc104dccf8b04edbb5aa713bc098790f94e932c4d4835baf133ad0d0R15): Added support for displaying the asset ticker next to the amount in the success screen, including updating the props and rendering logic.

* [`src/screens/assets/SendAssetScreen.tsx`](diffhunk://#diff-76de0d4bb2b51bfabd2909f1feea7114beae8fe259d05a58856da87a3de42fb3R876): Passed the asset ticker to the success screen component to enable the new display.

**Validation improvements:**

* [`src/screens/assets/SendAssetScreen.tsx`](diffhunk://#diff-76de0d4bb2b51bfabd2909f1feea7114beae8fe259d05a58856da87a3de42fb3L929-R930): Improved the validation check to ensure the asset amount is compared as numbers, preventing potential issues with string comparisons.